### PR TITLE
Fix vertical lines z-index in marey

### DIFF
--- a/src/js/viz_components/mareydiagram.js
+++ b/src/js/viz_components/mareydiagram.js
@@ -469,7 +469,8 @@ export default class MareyDiagram {
 
     // vehiclesPosSel.enter()
     //   .append('circle')
-    //   .attr('class', ({ status, prognosed }) => `position ${status} ${prognosed ? 'prognosed' : ''}`)
+    //   .attr('class', ({ status, prognosed }) =>
+    //     `position ${status} ${prognosed ? 'prognosed' : ''}`)
     //   .attr('r', '1.5')
     //   .attr('cx', ({ distance }) => this.xScale(distance))
     //   // Trip > vehicle > circle enter + update

--- a/src/js/viz_components/mareydiagram.js
+++ b/src/js/viz_components/mareydiagram.js
@@ -286,11 +286,11 @@ export default class MareyDiagram {
       .attr('transform', `translate(${this.dims.marey.innerWidth},0)`);
     this.yScrollAxisG = this.scrollGroup.append('g')
       .attr('class', 'scroll-axis axis');
+    this.xAxisG = this.diagGroup.append('g')
+      .attr('class', 'top-axis axis');
     this.tripsG = this.diagGroup.append('g')
       .attr('class', 'trips')
       .attr('clip-path', 'url(#clip-path)');
-    this.xAxisG = this.diagGroup.append('g')
-      .attr('class', 'top-axis axis');
     this.timelineG = this.diagGroup.append('g')
       .attr('class', 'timeline');
   }


### PR DESCRIPTION
It turns out that issue #21 can be now fixed by just swapping a couple of lines.
This is a consequence of the fact that we abandoned the integrated browser scrollbar for the new zoom/brush behaviour