### PR TITLE
Initial steps for multiple journey patterns

### DIFF
--- a/src/index.html
+++ b/src/index.html
@@ -32,10 +32,10 @@
           <label for="lines-groups">Lines</label>
           <select id="lines-groups"></select>
 
-          <!-- Make journey pattern selector initially invisible -->
-          <div class="jpSelect" style="display: none;">
-            <label for="journeyPattern">Journey Pattern</label>
-            <select id="journeyPattern"></select>
+          <!-- Make line - direction selector initially invisible -->
+          <div class="linedirectionSel" style="display: none;">
+            <label for="line-direction">Line - direction</label>
+            <select id="line-direction"></select>
           </div>
           <input class="button-primary close-sidebar" type="submit" value="Load">
         </fieldset>

--- a/src/js/app.js
+++ b/src/js/app.js
@@ -138,7 +138,7 @@ const formSubmit = (event) => {
         options.mode = 'dual';
         const [line, direction] = document.getElementById('line-direction').value.split(' - ');
         options.dual.line = line;
-        options.dual.direction = direction;
+        options.dual.direction = parseInt(direction, 10);
       } else {
         options.mode = 'spiralSimulation';
       }

--- a/src/js/ptds.js
+++ b/src/js/ptds.js
@@ -21,6 +21,17 @@ export default class PTDS {
     this.data = new PTDataset(inputData, options.selectedDate);
     this.options = options;
 
+    let maxNstops = -1;
+    let maxNstopsJP = '';
+    for (const journeyPattern of Object.values(this.data.journeyPatterns)) {
+      if (journeyPattern.stops.length > maxNstops) {
+        maxNstops = journeyPattern.stops.length;
+        maxNstopsJP = journeyPattern.code;
+      }
+    }
+
+    this.options.dual.journeyPattern = maxNstopsJP;
+
     this.widgetTimeFormat = d3.timeFormat('%Y-%m-%d %H:%M:%S');
 
     if (options.mode === 'spiralSimulation') { this.createSimulationWidget(); }
@@ -204,7 +215,7 @@ export default class PTDS {
         this.map.updateData({
           trips: this.getTripsAtTime(
             time,
-            trip => this.options.dual.journeyPatterns.includes(trip.journeyPattern.code),
+            trip => this.options.dual.journeyPattern === trip.journeyPattern.code,
           ),
         });
         this.map.drawTrips();
@@ -238,7 +249,7 @@ export default class PTDS {
       // If we're in dual mode, we're interested only in the data that belongs
       // to the chosen journey pattern(s). To filter the stops, stop areas and stops links
       // we first extract the stops belonging to the chosen journey pattern(s).
-      for (const journeyPatternRef of this.options.dual.journeyPatterns) {
+      for (const journeyPatternRef of [this.options.dual.journeyPattern]) {
         for (const stop of this.data.journeyPatterns[journeyPatternRef].stops) {
           validStops.push(stop);
         }
@@ -290,8 +301,7 @@ export default class PTDS {
    * }} - Data for the Marey diagram
    */
   getMareyData() {
-    // TODO: support multiple journey patterns
-    const journeyPatternCode = this.options.dual.journeyPatterns[0];
+    const journeyPatternCode = this.options.dual.journeyPattern;
     const journeyPattern = this.data.journeyPatterns[journeyPatternCode];
 
     // Trips that belong to the chosen journey pattern(s)

--- a/src/js/ptds.js
+++ b/src/js/ptds.js
@@ -25,7 +25,7 @@ export default class PTDS {
       let maxNstops = -1;
       let maxNstopsJP = '';
       for (const journeyPattern of Object.values(this.data.journeyPatterns)) {
-        if (journeyPattern.lineRef === options.dual.lineRef &&
+        if (journeyPattern.line.code === options.dual.line &&
             journeyPattern.direction === options.dual.direction &&
             journeyPattern.stops.length > maxNstops) {
           maxNstops = journeyPattern.stops.length;

--- a/src/js/ptds.js
+++ b/src/js/ptds.js
@@ -21,20 +21,22 @@ export default class PTDS {
     this.data = new PTDataset(inputData, options.selectedDate);
     this.options = options;
 
-    let maxNstops = -1;
-    let maxNstopsJP = '';
-    for (const journeyPattern of Object.values(this.data.journeyPatterns)) {
-      if (journeyPattern.stops.length > maxNstops) {
-        maxNstops = journeyPattern.stops.length;
-        maxNstopsJP = journeyPattern.code;
+    if (options.mode === 'dual') {
+      let maxNstops = -1;
+      let maxNstopsJP = '';
+      for (const journeyPattern of Object.values(this.data.journeyPatterns)) {
+        if (journeyPattern.lineRef === options.dual.lineRef &&
+            journeyPattern.direction === options.dual.direction &&
+            journeyPattern.stops.length > maxNstops) {
+          maxNstops = journeyPattern.stops.length;
+          maxNstopsJP = journeyPattern.code;
+        }
       }
+      this.options.dual.journeyPattern = maxNstopsJP;
+    } else if (options.mode === 'spiralSimulation') {
+      this.widgetTimeFormat = d3.timeFormat('%Y-%m-%d %H:%M:%S');
+      this.createSimulationWidget();
     }
-
-    this.options.dual.journeyPattern = maxNstopsJP;
-
-    this.widgetTimeFormat = d3.timeFormat('%Y-%m-%d %H:%M:%S');
-
-    if (options.mode === 'spiralSimulation') { this.createSimulationWidget(); }
 
     this.createVisualizations();
   }

--- a/src/js/viz_components/mareydiagram.js
+++ b/src/js/viz_components/mareydiagram.js
@@ -118,9 +118,13 @@ export default class MareyDiagram {
       // Same as above
       .on('brush end', () => { this.brushed(); });
 
+    // Select the first two hours in the domain in the beginning
+    const initialEndTime = this.yScrollScale.domain()[0];
+    initialEndTime.setHours(initialEndTime.getHours() + 2);
+
     this.scrollGroup
       .call(this.brushBehaviour)
-      .call(this.brushBehaviour.move, [0, this.yScrollScale.range()[1] / 4]);
+      .call(this.brushBehaviour.move, [0, this.yScrollScale(initialEndTime)]);
   }
 
   /**

--- a/src/js/viz_components/mareydiagram.js
+++ b/src/js/viz_components/mareydiagram.js
@@ -132,8 +132,11 @@ export default class MareyDiagram {
    * Set up the zoom and brush behaviours
    */
   zoomAndBrushSetup() {
+    // Since we haven't selected a range yet, this will get the domain of the entire day
+    const minutesInDomain = Math.floor(this.secondsInDomain / 60);
     this.zoomBehaviour = d3.zoom()
-      .scaleExtent([1, 2000])
+      // Base maximum zoom on the number of minutes in the domain for the current day
+      .scaleExtent([1, minutesInDomain * 1.6667])
       .extent([[0, 0], [this.dims.marey.innerWidth, this.dims.marey.innerHeight]])
       .translateExtent([[0, 0], [this.dims.marey.innerWidth, this.dims.marey.innerHeight]])
       // We encapsulate this.zoomed in a closure so that we don't lose the "this" context


### PR DESCRIPTION
As agreed, the first step to the support of multiple journey patterns is the selection of a certain line and direction.
The journey pattern with the selected line-direction combination that has the longest list of stops is taken as a reference, and drawn as before in the Marey.
On top of this, all the other journey patterns that share the same line and direction are drawn on top of the reference journey pattern.
For now, only the reference JP is drawn.