### PR TITLE
Multiple journey patterns

### DIFF
--- a/src/index.html
+++ b/src/index.html
@@ -32,10 +32,10 @@
           <label for="lines-groups">Lines</label>
           <select id="lines-groups"></select>
 
-          <!-- Make journey pattern selector initially invisible -->
-          <div class="jpSelect" style="display: none;">
-            <label for="journeyPattern">Journey Pattern</label>
-            <select id="journeyPattern"></select>
+          <!-- Make line - direction selector initially invisible -->
+          <div class="linedirectionSel" style="display: none;">
+            <label for="line-direction">Line - direction</label>
+            <select id="line-direction"></select>
           </div>
           <input class="button-primary close-sidebar" type="submit" value="Load">
         </fieldset>

--- a/src/js/app.js
+++ b/src/js/app.js
@@ -138,7 +138,7 @@ const formSubmit = (event) => {
         options.mode = 'dual';
         const [line, direction] = document.getElementById('line-direction').value.split(' - ');
         options.dual.line = line;
-        options.dual.direction = direction;
+        options.dual.direction = parseInt(direction, 10);
       } else {
         options.mode = 'spiralSimulation';
       }

--- a/src/js/app.js
+++ b/src/js/app.js
@@ -10,7 +10,7 @@ log.enableAll();
 const options = {
   stopRadius: 1,
   stopAreaRadius: 1,
-  tripRadius: 3,
+  tripRadius: 2,
   showStops: false,
   showStopAreas: true,
   showLinks: true,

--- a/src/js/models/journeypattern.js
+++ b/src/js/models/journeypattern.js
@@ -39,35 +39,51 @@ export default class JourneyPattern {
   }
 
   /**
-   * Finds shared links between the journey pattern and another one.
+   * Finds shared sequences of links between the journey pattern and another one.
    * A link is shared if it's between the same two stop areas.
    * @param  {JourneyPattern} otherJP - The other journey pattern
-   * @return {Array.<{
-     *         withinItself: [number, number],
-     *         withinOther: [number, number]
-   *         }>} - Array describing the correspondance between the links
-   *               in the two journey patterns
+   * @return {boolean|{referenceSequences: Array.<Array.<number>>,
+   *                   otherSequences: Array.<Array.<number>>}} - Array describing the
+   *  correspondance between the reference and the other journey pattern
    */
-  sharedLinks(otherJP) {
-    const result = [];
+  sharedSequences(otherJP) {
+    const referenceSequences = [];
+    const otherSequences = [];
 
-    for (let index = 0; index < this.stops.length - 1; index += 1) {
-      const jpStopA = this.stops[index];
-      const jpStopB = this.stops[index + 1];
+    for (let refIndex = 0; refIndex < this.stops.length - 1; refIndex += 1) {
+      const jpStopA = this.stops[refIndex];
+      const jpStopB = this.stops[refIndex + 1];
 
-      for (let index2 = 0; index2 < otherJP.stops.length - 1; index2 += 1) {
-        const otherJPStopA = otherJP.stops[index2];
-        const otherJPStopB = otherJP.stops[index2 + 1];
+      for (let otherIndex = 0; otherIndex < otherJP.stops.length - 1; otherIndex += 1) {
+        const otherJPStopA = otherJP.stops[otherIndex];
+        const otherJPStopB = otherJP.stops[otherIndex + 1];
 
         if (jpStopA.area === otherJPStopA.area && jpStopB.area === otherJPStopB.area) {
-          result.push({
-            withinItself: [index, index + 1],
-            withinOther: [index2, index2 + 1],
-          });
+          if (!referenceSequences.length) {
+            // If the reference sequences is list, add the first sequence with the found link
+            referenceSequences.push([refIndex, refIndex + 1]);
+            otherSequences.push([otherIndex, otherIndex + 1]);
+          } else {
+            // Get the last added reference sequence and index
+            const lastAddedRefSequence = referenceSequences[referenceSequences.length - 1];
+            const lastAddedRefIndex = lastAddedRefSequence[lastAddedRefSequence.length - 1];
+
+            // If the last added reference index is different than the current index, it means the
+            // link is non contiguous and therefore we start a new sequence
+            if (lastAddedRefIndex !== refIndex) {
+              referenceSequences.push([refIndex, refIndex + 1]);
+              otherSequences.push([otherIndex, otherIndex + 1]);
+            } else {
+              // Otherwise we are continuing a contiguous sequence
+              const lastAddedOtherSequence = otherSequences[otherSequences.length - 1];
+              lastAddedRefSequence.push(refIndex + 1);
+              lastAddedOtherSequence.push(otherIndex + 1);
+            }
+          }
         }
       }
     }
 
-    return result;
+    return referenceSequences.length ? { referenceSequences, otherSequences } : false;
   }
 }

--- a/src/js/models/journeypattern.js
+++ b/src/js/models/journeypattern.js
@@ -16,12 +16,6 @@ export default class JourneyPattern {
     this.distances = distances;
     this.line = line;
     this.direction = direction;
-
-    // Create Array with (stop, distance) pairs
-    this.stopsDistances = this.stops.map((stop, index) => ({
-      stop,
-      distance: this.distances[index],
-    }));
   }
 
   /**
@@ -47,18 +41,26 @@ export default class JourneyPattern {
    *  correspondance between the reference and the other journey pattern
    */
   sharedSequences(otherJP) {
+    // The idea is that in a "reference sequence" we store the index of the matching stops within
+    // the reference journey pattern while in the "other sequence" we store the index of the
+    // matching stops in the other journey pattern
     const referenceSequences = [];
     const otherSequences = [];
     let foundSharedLink = false;
 
+    // Iterate over the links of the JP
     for (let refIndex = 0; refIndex < this.stops.length - 1; refIndex += 1) {
+      // Extract (stopA, stopB) pairs
       const jpStopA = this.stops[refIndex];
       const jpStopB = this.stops[refIndex + 1];
 
+      // Iterate over the links of the other JP
       for (let otherIndex = 0; otherIndex < otherJP.stops.length - 1; otherIndex += 1) {
+        // Extract (oStopA, oStopB) pairs
         const otherJPStopA = otherJP.stops[otherIndex];
         const otherJPStopB = otherJP.stops[otherIndex + 1];
 
+        // If we find a shared link between the journey patterns (same stop areas)
         if (jpStopA.area === otherJPStopA.area && jpStopB.area === otherJPStopB.area) {
           foundSharedLink = true;
           if (!referenceSequences.length) {
@@ -86,6 +88,7 @@ export default class JourneyPattern {
       }
     }
 
+    // If no shared link was found, return false
     return foundSharedLink ? { referenceSequences, otherSequences } : false;
   }
 }

--- a/src/js/models/journeypattern.js
+++ b/src/js/models/journeypattern.js
@@ -49,6 +49,7 @@ export default class JourneyPattern {
   sharedSequences(otherJP) {
     const referenceSequences = [];
     const otherSequences = [];
+    let foundSharedLink = false;
 
     for (let refIndex = 0; refIndex < this.stops.length - 1; refIndex += 1) {
       const jpStopA = this.stops[refIndex];
@@ -59,6 +60,7 @@ export default class JourneyPattern {
         const otherJPStopB = otherJP.stops[otherIndex + 1];
 
         if (jpStopA.area === otherJPStopA.area && jpStopB.area === otherJPStopB.area) {
+          foundSharedLink = true;
           if (!referenceSequences.length) {
             // If the reference sequences is list, add the first sequence with the found link
             referenceSequences.push([refIndex, refIndex + 1]);
@@ -84,6 +86,6 @@ export default class JourneyPattern {
       }
     }
 
-    return referenceSequences.length ? { referenceSequences, otherSequences } : false;
+    return foundSharedLink ? { referenceSequences, otherSequences } : false;
   }
 }

--- a/src/js/models/journeypattern.js
+++ b/src/js/models/journeypattern.js
@@ -37,4 +37,37 @@ export default class JourneyPattern {
       last: Math.max(...combinedFirstAndLast.map(tripCombinedFL => tripCombinedFL.last)),
     };
   }
+
+  /**
+   * Finds shared links between the journey pattern and another one.
+   * A link is shared if it's between the same two stop areas.
+   * @param  {JourneyPattern} otherJP - The other journey pattern
+   * @return {Array.<{
+     *         withinItself: [number, number],
+     *         withinOther: [number, number]
+   *         }>} - Array describing the correspondance between the links
+   *               in the two journey patterns
+   */
+  sharedLinks(otherJP) {
+    const result = [];
+
+    for (let index = 0; index < this.stops.length - 1; index += 1) {
+      const jpStopA = this.stops[index];
+      const jpStopB = this.stops[index + 1];
+
+      for (let index2 = 0; index2 < otherJP.stops.length - 1; index2 += 1) {
+        const otherJPStopA = otherJP.stops[index2];
+        const otherJPStopB = otherJP.stops[index2 + 1];
+
+        if (jpStopA.area === otherJPStopA.area && jpStopB.area === otherJPStopB.area) {
+          result.push({
+            withinItself: [index, index + 1],
+            withinOther: [index2, index2 + 1],
+          });
+        }
+      }
+    }
+
+    return result;
+  }
 }

--- a/src/js/models/vehiclejourney.js
+++ b/src/js/models/vehiclejourney.js
@@ -20,7 +20,7 @@ export default class VehicleJourney {
     this.code = code;
     this.journeyPattern = journeyPattern;
     this.times = times;
-    this.realtime = realtime;
+    this.rt = realtime;
     this.cancelled = cancelled;
 
     // Compute static schedule as (time, distance) object pairs array
@@ -38,7 +38,7 @@ export default class VehicleJourney {
    * @return {boolean} - True if real time data is available, false otherwise
    */
   get isRealTime() {
-    return typeof this.realtime !== 'undefined' && Object.keys(this.realtime).length !== 0;
+    return typeof this.rt !== 'undefined' && Object.keys(this.rt).length !== 0;
   }
 
   /**
@@ -49,7 +49,7 @@ export default class VehicleJourney {
   get firstAndLastTimes() {
     if (this.isRealTime) {
       // Extract first and last realtime time for each vehicle
-      const combinedFirstAndLast = Object.values(this.realtime)
+      const combinedFirstAndLast = Object.values(this.rt)
         .filter(({ times }) => times.length > 0)
         .map(({ times }) => ({ first: times[0], last: times[times.length - 1] }));
 
@@ -81,7 +81,7 @@ export default class VehicleJourney {
     // If realtime data is available, the trip is considered active
     // if at least one of the vehicles is active
     if (this.isRealTime) {
-      return Object.values(this.realtime).some(({ times }) =>
+      return Object.values(this.rt).some(({ times }) =>
         times[0] <= time && time <= times[times.length - 1]);
     }
 
@@ -129,33 +129,43 @@ export default class VehicleJourney {
   }
 
   /**
-   * Computes the realtime positions information of a the vehicles belonging to this journey
+   * Computes the realtime positions information of the vehicles belonging to this journey
    * @return {Array.<{
-   *           vehichleNumber: number,
-   *           positions: {time: Date, distance: number, status: string, prognosed: boolean}
+   *           vehicleNumber: number,
+   *           positions: {time: Date, distanceSinceLastStop: number, distanceFromStart: number,
+   *           status: string, prognosed: boolean}
    *          }>} - List of enriched realtime position info
    */
   get realTimeData() {
     if (!this.isRealTime) return [];
 
-    return Object.values(this.realtime).map(({ vehicleNumber, times, distances }) => ({
+    // Extract array of static schedule distances at each stop
+    const staticDistances = this.journeyPattern.distances;
+
+    return Object.values(this.rt).map(({ vehicleNumber, times, distances }) => ({
       vehicleNumber,
-      // For each vehicle, enrich its positions information by computing the "on time"
-      // status at each position
+      // Enrich the vehicles position data with the distance since the last stop
+      // and the index of that stop, as well as the status compared to the schedule
       positions: times.map((time, index) => {
         const distance = distances[index];
-        const staticDistances = Array.from(this.staticSchedule.map(({ distance: d }) => d));
         let lastStopIndex;
         let distanceSinceLastStop;
 
+        // If the current distance is smaller or equal than the distance of the last stop
+        // (typically they're both 0) then the last stop is the first one and the distance is 0
         if (distance <= staticDistances[0]) {
           lastStopIndex = 0;
           distanceSinceLastStop = 0;
+        // If the distance is greater than the distance of the last stop of the journey, then
+        // use the one-to-last stop of the journey as the last stop and the distance between the
+        // last and one-to-last stops as distance from the last stop
         } else if (distance >= staticDistances[staticDistances.length - 1]) {
           lastStopIndex = staticDistances.length - 2;
           distanceSinceLastStop = staticDistances[staticDistances.length - 1] -
                                   staticDistances[staticDistances.length - 2];
         } else {
+          // Else, scan the schedule to see in which link the vehicle currently is and compute
+          // the last stop index and distance from last stop consequently
           for (let i = 0; i < staticDistances.length - 1; i += 1) {
             if (staticDistances[i] <= distance && distance < staticDistances[i + 1]) {
               lastStopIndex = i;
@@ -233,7 +243,8 @@ export default class VehicleJourney {
     };
 
     if (this.isRealTime) {
-      return Object.values(this.realtime)
+      return Object.values(this.rt)
+        // Filter out actually-not-realtime vehicles
         .filter(({ times, distances }) => times.length > 0 && distances.length > 0)
         .map(({ vehicleNumber, times, distances }) => {
           const distance = getDistanceGivenSchedule(times.map((_time, index) =>
@@ -252,7 +263,7 @@ export default class VehicleJourney {
     const distance = getDistanceGivenSchedule(this.staticSchedule);
 
     return [{
-      vehicleNumber: -1, // use fictitious vehicle number for static data
+      vehicleNumber: -1, // Use fictitious vehicle number for static data
       distance,
       position: this.getPositionFromDistance(distance, stopsLinks),
       status: VehicleStatus.UNDEFINED,

--- a/src/js/models/vehiclejourney.js
+++ b/src/js/models/vehiclejourney.js
@@ -24,14 +24,12 @@ export default class VehicleJourney {
     this.cancelled = cancelled;
 
     // Compute static schedule as (time, distance) object pairs array
-    this.staticSchedule = this.times
-      .map((time, index) => ({
-        time,
+    this.staticSchedule = this.journeyPattern.distances
+      .map((distance, index) => ({
+        distance,
         // The times array is double the length of the distances array,
         // because we have for each stop the arrival and departure time.
-        // Therefore we take the distance element with index corresponding
-        // to half the index of the corresponding time element
-        distance: this.journeyPattern.distances[Math.floor(index / 2)],
+        time: this.times[index * 2],
       }));
   }
 

--- a/src/js/ptds.js
+++ b/src/js/ptds.js
@@ -66,8 +66,10 @@ export default class PTDS {
 
     // Compute the shared sequences between the longest journey pattern and all the other ones
     for (const journeyPattern of Object.values(this.data.journeyPatterns)) {
-      const sharedSequences = maxNstopsJP.sharedSequences(journeyPattern);
-      if (sharedSequences) { journeyPatternMix.otherJPs.push({ journeyPattern, sharedSequences }); }
+      if (journeyPattern.code !== maxNstopsJP.code) {
+        const sharedSequences = maxNstopsJP.sharedSequences(journeyPattern);
+        if (sharedSequences) journeyPatternMix.otherJPs.push({ journeyPattern, sharedSequences });
+      }
     }
 
     return journeyPatternMix;

--- a/src/js/ptds.js
+++ b/src/js/ptds.js
@@ -46,6 +46,8 @@ export default class PTDS {
   computeJourneyPatternMix() {
     let maxNstops = -1;
     let maxNstopsJP;
+
+    // Find the longest journey pattern with the given line and direction (most stops)
     for (const journeyPattern of Object.values(this.data.journeyPatterns)) {
       if (journeyPattern.line.code === this.options.dual.line &&
           journeyPattern.direction === this.options.dual.direction &&
@@ -60,6 +62,7 @@ export default class PTDS {
       otherJPs: [],
     };
 
+    // Compute the shared links between the longest journey pattern and all the other ones
     for (const journeyPattern of Object.values(this.data.journeyPatterns)) {
       const sharedLinks = maxNstopsJP.sharedLinks(journeyPattern);
       if (sharedLinks.length) {

--- a/src/js/ptds.js
+++ b/src/js/ptds.js
@@ -22,29 +22,7 @@ export default class PTDS {
     this.options = options;
 
     if (options.mode === 'dual') {
-      let maxNstops = -1;
-      let maxNstopsJP;
-      for (const journeyPattern of Object.values(this.data.journeyPatterns)) {
-        if (journeyPattern.line.code === options.dual.line &&
-            journeyPattern.direction === options.dual.direction &&
-            journeyPattern.stops.length > maxNstops) {
-          maxNstops = journeyPattern.stops.length;
-          maxNstopsJP = journeyPattern;
-        }
-      }
-
-      this.journeyPatternMix = {
-        referenceJP: maxNstopsJP,
-        otherJPs: [],
-      };
-
-      for (const journeyPattern of Object.values(this.data.journeyPatterns)) {
-        const sharedLinks = maxNstopsJP.sharedLinks(journeyPattern);
-        if (sharedLinks.length) {
-          this.journeyPatternMix.otherJPs.push({ journeyPattern, sharedLinks });
-        }
-      }
-
+      this.journeyPatternMix = this.computeJourneyPatternMix();
       console.log(this.journeyPatternMix);
     } else if (options.mode === 'spiralSimulation') {
       this.widgetTimeFormat = d3.timeFormat('%Y-%m-%d %H:%M:%S');
@@ -52,6 +30,44 @@ export default class PTDS {
     }
 
     this.createVisualizations();
+  }
+
+  /**
+   * Used in the dual visualization mode, computes the object representing the mix of journey
+   * patterns that we are going to visualize.
+   * @return {{
+   *         referenceJP: JourneyPattern,
+   *         otherJPs: {
+   *           journeyPattern: JourneyPattern,
+   *           sharedLinks: [[number, number], [number, number]]
+   *         }
+   * }} - Object representing the mix of journey patterns to display
+   */
+  computeJourneyPatternMix() {
+    let maxNstops = -1;
+    let maxNstopsJP;
+    for (const journeyPattern of Object.values(this.data.journeyPatterns)) {
+      if (journeyPattern.line.code === this.options.dual.line &&
+          journeyPattern.direction === this.options.dual.direction &&
+          journeyPattern.stops.length > maxNstops) {
+        maxNstops = journeyPattern.stops.length;
+        maxNstopsJP = journeyPattern;
+      }
+    }
+
+    const journeyPatternMix = {
+      referenceJP: maxNstopsJP,
+      otherJPs: [],
+    };
+
+    for (const journeyPattern of Object.values(this.data.journeyPatterns)) {
+      const sharedLinks = maxNstopsJP.sharedLinks(journeyPattern);
+      if (sharedLinks.length) {
+        journeyPatternMix.otherJPs.push({ journeyPattern, sharedLinks });
+      }
+    }
+
+    return journeyPatternMix;
   }
 
   /**

--- a/src/js/ptds.js
+++ b/src/js/ptds.js
@@ -21,6 +21,17 @@ export default class PTDS {
     this.data = new PTDataset(inputData, options.selectedDate);
     this.options = options;
 
+    let maxNstops = -1;
+    let maxNstopsJP = '';
+    for (const journeyPattern of Object.values(this.data.journeyPatterns)) {
+      if (journeyPattern.stops.length > maxNstops) {
+        maxNstops = journeyPattern.stops.length;
+        maxNstopsJP = journeyPattern.code;
+      }
+    }
+
+    this.options.dual.journeyPattern = maxNstopsJP;
+
     this.widgetTimeFormat = d3.timeFormat('%Y-%m-%d %H:%M:%S');
 
     if (options.mode === 'spiralSimulation') { this.createSimulationWidget(); }
@@ -204,7 +215,7 @@ export default class PTDS {
         this.map.updateData({
           trips: this.getTripsAtTime(
             time,
-            trip => this.options.dual.journeyPatterns.includes(trip.journeyPattern.code),
+            trip => this.options.dual.journeyPattern === trip.journeyPattern.code,
           ),
         });
         this.map.drawTrips();
@@ -238,7 +249,7 @@ export default class PTDS {
       // If we're in dual mode, we're interested only in the data that belongs
       // to the chosen journey pattern(s). To filter the stops, stop areas and stops links
       // we first extract the stops belonging to the chosen journey pattern(s).
-      for (const journeyPatternRef of this.options.dual.journeyPatterns) {
+      for (const journeyPatternRef of [this.options.dual.journeyPattern]) {
         for (const stop of this.data.journeyPatterns[journeyPatternRef].stops) {
           validStops.push(stop);
         }
@@ -290,8 +301,7 @@ export default class PTDS {
    * }} - Data for the Marey diagram
    */
   getMareyData() {
-    // TODO: support multiple journey patterns
-    const journeyPatternCode = this.options.dual.journeyPatterns[0];
+    const journeyPatternCode = this.options.dual.journeyPattern;
     const journeyPattern = this.data.journeyPatterns[journeyPatternCode];
 
     // Trips that belong to the chosen journey pattern(s)

--- a/src/js/ptds.js
+++ b/src/js/ptds.js
@@ -25,7 +25,7 @@ export default class PTDS {
       let maxNstops = -1;
       let maxNstopsJP = '';
       for (const journeyPattern of Object.values(this.data.journeyPatterns)) {
-        if (journeyPattern.lineRef === options.dual.lineRef &&
+        if (journeyPattern.line.code === options.dual.line &&
             journeyPattern.direction === options.dual.direction &&
             journeyPattern.stops.length > maxNstops) {
           maxNstops = journeyPattern.stops.length;

--- a/src/js/ptds.js
+++ b/src/js/ptds.js
@@ -39,7 +39,10 @@ export default class PTDS {
    *         referenceJP: JourneyPattern,
    *         otherJPs: {
    *           journeyPattern: JourneyPattern,
-   *           sharedLinks: [[number, number], [number, number]]
+   *           sharedSequences: {
+   *              referenceSequences: Array.<Array.<number>>,
+   *              otherSequences: Array.<Array.<number>>
+   *            }
    *         }
    * }} - Object representing the mix of journey patterns to display
    */
@@ -62,12 +65,10 @@ export default class PTDS {
       otherJPs: [],
     };
 
-    // Compute the shared links between the longest journey pattern and all the other ones
+    // Compute the shared sequences between the longest journey pattern and all the other ones
     for (const journeyPattern of Object.values(this.data.journeyPatterns)) {
-      const sharedLinks = maxNstopsJP.sharedLinks(journeyPattern);
-      if (sharedLinks.length) {
-        journeyPatternMix.otherJPs.push({ journeyPattern, sharedLinks });
-      }
+      const sharedSequences = maxNstopsJP.sharedSequences(journeyPattern);
+      if (sharedSequences) { journeyPatternMix.otherJPs.push({ journeyPattern, sharedSequences }); }
     }
 
     return journeyPatternMix;

--- a/src/js/ptds.js
+++ b/src/js/ptds.js
@@ -21,20 +21,22 @@ export default class PTDS {
     this.data = new PTDataset(inputData, options.selectedDate);
     this.options = options;
 
-    let maxNstops = -1;
-    let maxNstopsJP = '';
-    for (const journeyPattern of Object.values(this.data.journeyPatterns)) {
-      if (journeyPattern.stops.length > maxNstops) {
-        maxNstops = journeyPattern.stops.length;
-        maxNstopsJP = journeyPattern.code;
+    if (options.mode === 'dual') {
+      let maxNstops = -1;
+      let maxNstopsJP = '';
+      for (const journeyPattern of Object.values(this.data.journeyPatterns)) {
+        if (journeyPattern.lineRef === options.dual.lineRef &&
+            journeyPattern.direction === options.dual.direction &&
+            journeyPattern.stops.length > maxNstops) {
+          maxNstops = journeyPattern.stops.length;
+          maxNstopsJP = journeyPattern.code;
+        }
       }
+      this.options.dual.journeyPattern = maxNstopsJP;
+    } else if (options.mode === 'spiralSimulation') {
+      this.widgetTimeFormat = d3.timeFormat('%Y-%m-%d %H:%M:%S');
+      this.createSimulationWidget();
     }
-
-    this.options.dual.journeyPattern = maxNstopsJP;
-
-    this.widgetTimeFormat = d3.timeFormat('%Y-%m-%d %H:%M:%S');
-
-    if (options.mode === 'spiralSimulation') { this.createSimulationWidget(); }
 
     this.createVisualizations();
   }

--- a/src/js/ptds.js
+++ b/src/js/ptds.js
@@ -79,7 +79,6 @@ export default class PTDS {
    * Create the SVG elements
    */
   createSVGObjects() {
-    /* eslint global-require: "off" */
     // Get browser dimensions
     // The correction factors are needed because the actual size
     // available is less than the one returned by the browser due to scrollbars
@@ -248,13 +247,17 @@ export default class PTDS {
     if (this.options.mode === 'dual') {
       // Callback that updates the map when the timeline is moved in the Marey diagram
       const timelineChangeCallback = (time) => {
+        // Extract the codes of all the journey patterns shown (reference + others sharing >1 link)
+        const selectedJPcodes = [
+          this.journeyPatternMix.referenceJP.code,
+          ...this.journeyPatternMix.otherJPs.map(({ journeyPattern }) => journeyPattern.code),
+        ];
+
         this.map.updateData({
           trips: this.getTripsAtTime(
             time,
-            trip => (this.journeyPatternMix.referenceJP.code === trip.journeyPattern.code ||
-                     this.journeyPatternMix.otherJPs
-                       .map(({ journeyPattern }) => journeyPattern.code)
-                       .includes(trip.journeyPattern.code)),
+            // Display on the map only the trips that we're showing in the diagram
+            trip => selectedJPcodes.includes(trip.journeyPattern.code),
           ),
         });
         this.map.drawTrips();
@@ -266,7 +269,6 @@ export default class PTDS {
         this.mareySVGgroup,
         this.scrollSVGgroup,
         this.dims,
-        this.options,
         timelineChangeCallback,
       );
     }
@@ -326,43 +328,6 @@ export default class PTDS {
 
     return { stops: validStops, stopAreas, links, trips: [] };
   }
-
-  /**
-   * Get the data needed to draw the Marey diagram
-   * @return {{
-   *   trips: Array.<{
-   *     code: string,
-   *     schedule: Array.<{time: Date, distance: number}>,
-   *     vehicles: Array.<{
-   *       vehichleNumber: number,
-   *       positions: {time: Date, distance: number, status: string, prognosed: boolean}
-   *     }>,
-   *     timeBoundaries: {first: Date, last: Date}
-   *   }>,
-   *   stopsDistances: Array.<{stop: Stop, distance: number}>,
-   *   timeBoundaries: {first: Date, last: Date}
-   * }} - Data for the Marey diagram
-   */
-  // getMareyData() {
-  //   const { referenceJP } = this.journeyPatternMix;
-
-  //   // Trips that belong to the chosen journey pattern(s)
-  //   const trips = referenceJP.vehicleJourneys;
-
-  //   // Create trips list with essential information for the Marey diagram
-  //   const tripsProcessed = trips.map(trip => ({
-  //     code: trip.code,
-  //     schedule: trip.staticSchedule,
-  //     vehicles: trip.getVehiclePositions(),
-  //     timeBoundaries: trip.firstAndLastTimes,
-  //   }));
-
-  //   return {
-  //     trips: tripsProcessed,
-  //     stopsDistances: referenceJP.stopsDistances,
-  //     timeBoundaries: referenceJP.firstAndLastTimes,
-  //   };
-  // }
 
   /**
    * Get all the trips active at a given time. It supports a filter

--- a/src/js/ptds.js
+++ b/src/js/ptds.js
@@ -257,7 +257,7 @@ export default class PTDS {
 
       // Creation of the Marey diagram
       this.marey = new MareyDiagram(
-        this.getMareyData(),
+        this.journeyPatternMix,
         this.mareySVGgroup,
         this.scrollSVGgroup,
         this.dims,
@@ -338,26 +338,26 @@ export default class PTDS {
    *   timeBoundaries: {first: Date, last: Date}
    * }} - Data for the Marey diagram
    */
-  getMareyData() {
-    const { referenceJP } = this.journeyPatternMix;
+  // getMareyData() {
+  //   const { referenceJP } = this.journeyPatternMix;
 
-    // Trips that belong to the chosen journey pattern(s)
-    const trips = referenceJP.vehicleJourneys;
+  //   // Trips that belong to the chosen journey pattern(s)
+  //   const trips = referenceJP.vehicleJourneys;
 
-    // Create trips list with essential information for the Marey diagram
-    const tripsProcessed = trips.map(trip => ({
-      code: trip.code,
-      schedule: trip.staticSchedule,
-      vehicles: trip.getVehiclePositions(),
-      timeBoundaries: trip.firstAndLastTimes,
-    }));
+  //   // Create trips list with essential information for the Marey diagram
+  //   const tripsProcessed = trips.map(trip => ({
+  //     code: trip.code,
+  //     schedule: trip.staticSchedule,
+  //     vehicles: trip.getVehiclePositions(),
+  //     timeBoundaries: trip.firstAndLastTimes,
+  //   }));
 
-    return {
-      trips: tripsProcessed,
-      stopsDistances: referenceJP.stopsDistances,
-      timeBoundaries: referenceJP.firstAndLastTimes,
-    };
-  }
+  //   return {
+  //     trips: tripsProcessed,
+  //     stopsDistances: referenceJP.stopsDistances,
+  //     timeBoundaries: referenceJP.firstAndLastTimes,
+  //   };
+  // }
 
   /**
    * Get all the trips active at a given time. It supports a filter

--- a/src/js/ptds.js
+++ b/src/js/ptds.js
@@ -23,7 +23,6 @@ export default class PTDS {
 
     if (options.mode === 'dual') {
       this.journeyPatternMix = this.computeJourneyPatternMix();
-      console.log(this.journeyPatternMix);
     } else if (options.mode === 'spiralSimulation') {
       this.widgetTimeFormat = d3.timeFormat('%Y-%m-%d %H:%M:%S');
       this.createSimulationWidget();

--- a/src/js/viz_components/mareydiagram.js
+++ b/src/js/viz_components/mareydiagram.js
@@ -30,15 +30,25 @@ const d3 = Object.assign({}, {
  * This class manages the Marey diagram visualization.
  */
 export default class MareyDiagram {
-  constructor(journeyPatternMix, diagGroup, scrollGroup, dims, options, changeCallback) {
+  /**
+   *
+   * @param {Object} journeyPatternMix - Information to draw on the diagram
+   * @param {Object} diagGroup - SVG element of the diagram
+   * @param {Object} scrollGroup - SVG element of the scrollbar/brush
+   * @param {Object} dims - Dimensions of the diagram
+   * @param {Function} changeCallback - Callback for the time change
+   */
+  constructor(journeyPatternMix, diagGroup, scrollGroup, dims, changeCallback) {
     this.journeyPatternMix = journeyPatternMix;
     this.diagGroup = diagGroup;
     this.scrollGroup = scrollGroup;
     this.dims = dims;
-    this.options = options;
 
+    // Compute information needed to draw the trips
     this.trips = this.computeTrips();
+    // Perform initial set-up of the diagram
     this.initialSetup(changeCallback);
+    // Draw the trips in the diagram
     this.drawTrips();
   }
 
@@ -66,26 +76,27 @@ export default class MareyDiagram {
   }
 
   /**
-   * Initial setup of the visualization, including svg group creation,
+   * Initial setup of the visualization, including SVG group creation,
    * scales creation, axes and timeline drawing.
    * @param  {Function} changeCallback - Callback for the timeline change event
    */
   initialSetup(changeCallback) {
+    // Time formatter for the timeline tooltip
     this.timelineTimeFormat = d3.timeFormat('%H:%M:%S');
 
     this.computeTimeBoundaries();
 
-    // Add 10 min offset to improve readability
+    // Expand the time boundaries by 10 minutes to improve readability of the diagram
     this.minTime = d3.timeMinute.offset(this.minTime, -10);
     this.maxTime = d3.timeMinute.offset(this.maxTime, +10);
 
     // Rectangle that clips the trips, so that when we zoom they don't
-    // end up out of the main graph
+    // end up outside of the main diagram
     this.diagGroup.append('clipPath')
       .attr('id', 'clip-path')
       .append('rect')
       // Use a 5px margin on the sides so that the circles representing the stops
-      // are entirely visible
+      // are entirely visible even at the first and last stop
       .attr('x', -5)
       .attr('width', this.dims.marey.innerWidth + 5)
       .attr('height', this.dims.marey.innerHeight);
@@ -95,8 +106,7 @@ export default class MareyDiagram {
       .x(({ distance }) => this.xScale(distance))
       .y(({ time }) => this.yScale(time));
 
-    // Overlay to listen to mouse movement (and update the timeline)
-    // and listen to zoom/pan events
+    // Overlay to capture mouse events (movement of the timeline, zoom/pan)
     this.overlay = this.diagGroup.append('rect')
       .attr('class', 'overlay')
       .attr('width', this.dims.marey.innerWidth)
@@ -112,7 +122,7 @@ export default class MareyDiagram {
   }
 
   /**
-   * Establishes approximation to use in terms of poslinks approximation
+   * Establishes approximation to use in terms of rt-links approximation
    * and showing or not the position dots
    * @return {{minSecondsDelta: number, showPosDots: boolean}} - Object describing the approximation
    */
@@ -120,10 +130,15 @@ export default class MareyDiagram {
     let minSecondsDelta;
     let showPosDots = false;
 
-    if (this.secondsInDomain > 120 * 60) {
+    // If there are more than 1.5 hours in the selected domain, space the position measurements
+    // at least 120 seconds one from each other
+    if (this.secondsInSelectedDomain > 90 * 60) {
       minSecondsDelta = 120;
-    } else if (this.secondsInDomain > 60 * 60) {
+    // If there is more than 1 hour in the selected domain, the min spacing is 30 seconds
+    } else if (this.secondsInSelectedDomain > 60 * 60) {
       minSecondsDelta = 30;
+    // If there is less than one hour we have no minimum spacing (= we show all the measurements)
+    // and we also show the circles in correspondance of them
     } else {
       minSecondsDelta = 0;
       showPosDots = true;
@@ -133,12 +148,12 @@ export default class MareyDiagram {
   }
 
   /**
-   * Number of seconds in the current domain of the Marey diagram
-   * @return {Number} - Seconds in current domain of the Marey diagram
+   * Number of seconds in the selected domain of the Marey diagram
+   * @return {Number} - Seconds in selected domain of the Marey diagram
    */
-  get secondsInDomain() {
-    const yDomain = this.yScale.domain();
-    return (yDomain[1] - yDomain[0]) / 1000;
+  get secondsInSelectedDomain() {
+    const ySelectedDomain = this.yScale.domain();
+    return (ySelectedDomain[1] - ySelectedDomain[0]) / 1000;
   }
 
   /**
@@ -149,7 +164,7 @@ export default class MareyDiagram {
    * @return {Function} - Time formatter
    */
   get yAxisTimeFormatter() {
-    if (this.secondsInDomain < 15 * 60) return d3.timeFormat('%H:%M:%S');
+    if (this.secondsInSelectedDomain < 15 * 60) return d3.timeFormat('%H:%M:%S');
     return d3.timeFormat('%H:%M');
   }
 
@@ -158,15 +173,17 @@ export default class MareyDiagram {
    */
   zoomAndBrushSetup() {
     // Since we haven't selected a range yet, this will get the domain of the entire day
-    const minutesInDomain = Math.floor(this.secondsInDomain / 60);
+    const minutesInTotalDomain = Math.floor(this.secondsInSelectedDomain / 60);
     this.zoomBehaviour = d3.zoom()
-      // Base maximum zoom on the number of minutes in the domain for the current day
-      .scaleExtent([1, minutesInDomain * 1.6667])
+      // Base maximum zoom on the number of minutes in the domain for the current day.
+      // The 1.6667 constant is empirically determined so that at the maximum zoom level
+      // the granularity is seconds.
+      .scaleExtent([1, minutesInTotalDomain * 1.6667])
       .extent([[0, 0], [this.dims.marey.innerWidth, this.dims.marey.innerHeight]])
       .translateExtent([[0, 0], [this.dims.marey.innerWidth, this.dims.marey.innerHeight]])
       // We encapsulate this.zoomed in a closure so that we don't lose the "this" context
       .on('zoom', () => { this.zoomed(); });
-
+    // Attach zoom behaviour to SVG group
     this.diagGroup.call(this.zoomBehaviour);
 
     this.brushBehaviour = d3.brushY()
@@ -182,6 +199,7 @@ export default class MareyDiagram {
       [, initialEndTime] = this.yScrollScale.domain();
     }
 
+    // Attach brush behaviour to SVG group and set initial selection
     this.scrollGroup
       .call(this.brushBehaviour)
       .call(this.brushBehaviour.move, [0, this.yScrollScale(initialEndTime)]);
@@ -191,15 +209,23 @@ export default class MareyDiagram {
    * Handle the brush selection
    */
   brushed() {
-    // When the zoom event is triggered, the zoom handler
-    // triggers a brush event to sync the two parts,
-    // but we don't want to handle the brush in that case.
+    // When the zoom event is triggered, the zoom handler triggers a brush event to sync
+    // the two parts, but we don't want to handle the brush as usual in that case
     if (d3event.sourceEvent && d3event.sourceEvent.type === 'zoom') return;
 
     // Get the brush selection
-    const selection = d3event.selection || this.yScrollScale.range();
+    const { selection } = d3event;
 
-    // Make it impossible to select a null extent
+    // If the selection is empty, select the full range
+    if (!selection) {
+      this.scrollGroup.call(
+        this.brushBehaviour.move,
+        this.yScrollScale.range(),
+      );
+      return;
+    }
+
+    // Make it impossible to perform a 0px selection
     if (selection[0] === selection[1]) {
       this.scrollGroup.call(
         this.brushBehaviour.move,
@@ -208,7 +234,7 @@ export default class MareyDiagram {
       return;
     }
 
-    // Update the marey y scale domain
+    // Update the Marey y scale domain
     this.yScale.domain(selection.map(this.yScrollScale.invert));
 
     // Update marey axes
@@ -250,7 +276,7 @@ export default class MareyDiagram {
       // If the event is triggered by the scroll of the mouse wheel and the shift key
       // is not pressed, we interpret it as PAN
       if (d3event.sourceEvent.type === 'wheel' && !d3event.sourceEvent.shiftKey) {
-        // Get the current domain in the marey diagram y axis
+        // Get the current domain in the Marey diagram y axis
         const selectedDomain = this.yScale.domain();
         // Compute number of seconds in the selected domain
         const secondsInSelectedDomain = (selectedDomain[1] - selectedDomain[0]) / 1000;
@@ -315,7 +341,7 @@ export default class MareyDiagram {
       this.yScale.domain().map(this.yScrollScale),
     );
 
-    // Update the marey y axes
+    // Update the Marey y axes
     this.refreshAxes();
 
     // Update the trips
@@ -326,9 +352,10 @@ export default class MareyDiagram {
    * Create x and y scales for the visualization, used to draw the axes and the trips
    */
   createScales() {
-    const refJPdistances = this.journeyPatternMix.referenceJP.distances;
+    const referenceJPstopsDistances = this.journeyPatternMix.referenceJP.distances;
+    const lastStopDistance = referenceJPstopsDistances[referenceJPstopsDistances.length - 1];
     this.xScale = d3.scaleLinear()
-      .domain([0, refJPdistances[refJPdistances.length - 1]])
+      .domain([0, lastStopDistance])
       .range([0, this.dims.marey.innerWidth]);
     this.yScale = d3.scaleTime()
       .domain([this.minTime, this.maxTime])
@@ -361,7 +388,7 @@ export default class MareyDiagram {
   }
 
   /**
-   * Vertical axes drawing, left and right
+   * Vertical axes drawing, left and rights
    */
   drawYAxes() {
     this.yLeftAxis = d3.axisLeft(this.yScale)
@@ -400,24 +427,30 @@ export default class MareyDiagram {
       .attr('data-stop-area-code', ({ area: { code } }) => code)
       .on('mouseover', function f(stop) {
         const stopAreaCode = stop.area.code;
-        d3.select(`#map g.stopArea[data-stop-area-code='${stopAreaCode}'] circle`).attr('r', 3);
+        // TODO: radius when selected and non selected (below) should be specified as a config
+        // options somewhere else
+        const selectedStopAreaRadius = 3;
+        d3.select(`#map g.stopArea[data-stop-area-code='${stopAreaCode}'] circle`)
+          .attr('r', selectedStopAreaRadius);
         d3.select(this).classed('selected', true);
       })
       .on('mouseout', function f(stop) {
         const stopAreaCode = stop.area.code;
-        d3.select(`#map g.stopArea[data-stop-area-code='${stopAreaCode}'] circle`).attr('r', 1);
+        const deselectedStopAreaRadius = 1;
+        d3.select(`#map g.stopArea[data-stop-area-code='${stopAreaCode}'] circle`)
+          .attr('r', deselectedStopAreaRadius);
         d3.select(this).classed('selected', false);
       });
 
     this.xAxisG.selectAll('text')
       .attr('x', 5)
-      .attr('dy', '.35em');
+      .attr('y', 4);
   }
 
   /**
    * Create the horizontal line representing the timeline
    * and make it move when the mouse is hovered in the canvas
-   * @param  {Function} changeCallback - Callback to trigger when the timeline is moved
+   * @param {Function} changeCallback - Callback to trigger when the timeline is moved
    */
   createTimeline(changeCallback) {
     // Initial position of the timeline
@@ -426,11 +459,11 @@ export default class MareyDiagram {
     // Timeline initial position
     this.timelineG.attr('transform', `translate(0,${initialTimelineYpos})`);
 
-    // Horizontal line
+    // Horizontal line drawing
     this.timelineG.append('line')
       .attr('x2', this.dims.marey.innerWidth)
       // Keep the line slightly below the mouse cursor so that it doesn't capture
-      // all the mouse events, passing them to the elements below
+      // all the mouse events, letting the elements "below" to listen to them
       .attr('y1', 1)
       .attr('y2', 1);
 
@@ -470,21 +503,22 @@ export default class MareyDiagram {
   }
 
   /**
-   * Given a list of vehicle positions, get the links between them.
+   * Given a sequence of vehicle positions, get the links between them.
    * Basing on the current domain of the diagram, it approximates the positions
    * to reduce the amount of links to be drawn.
-   * @param  {Array.<{time: Date, distance: number, status: string}>} positions - Positions info
+   * @param  {Array.<{time: Date, distance: number,
+   *                  status: string, prognosed: boolean}>} sequence - Positions info
    * @return {Array.<{timeA: Date, timeB: Date,
    *           distanceA: number, distanceB: number,
    *           status: string, prognosed: boolean}>} - Positions links information
    */
-  getPositionLinks(positions) {
+  getRealtimeLinks(sequence) {
     const posLinks = [];
     let index = 0;
 
-    while (index < positions.length - 1) {
-      const posA = positions[index];
-      let posB = positions[index + 1];
+    while (index < sequence.length - 1) {
+      const posA = sequence[index];
+      let posB = sequence[index + 1];
       const timeA = posA.time;
       let timeB = posB.time;
 
@@ -492,11 +526,11 @@ export default class MareyDiagram {
       // apart from the first one, skip it and move to the next "second position".
       // Only if the first and second position of the segment have the same status,
       // so that if a vehicle changed its status we don't skip the position
-      while (index < positions.length - 2 &&
+      while (index < sequence.length - 2 &&
              posA.status === posB.status &&
              timeB - timeA < this.currentApproximation.minSecondsDelta * 1000) {
         index += 1;
-        posB = positions[index + 1];
+        posB = sequence[index + 1];
         timeB = posB.time;
       }
 
@@ -512,19 +546,19 @@ export default class MareyDiagram {
   }
 
   /**
-   *  Compute information needed to draw the trips on the Marey diagram
+   * Compute information needed to draw the trips on the Marey diagram
    * @return {Object} - Trip drawing information
    */
   computeTrips() {
+    // Compute drawing information for the trips of the reference journey pattern
     const trips = this.journeyPatternMix.referenceJP.vehicleJourneys
       .map(({ code, staticSchedule, firstAndLastTimes, realTimeData }) => ({
         code,
         // For the reference journey pattern there is only one sequence
-        staticSequences: [
-          staticSchedule.map(({ time, distance }) => ({ time, distance })),
-        ],
+        staticSequences: [staticSchedule.map(({ time, distance }) => ({ time, distance }))],
         realtimeSequences: realTimeData.map(({ vehicleNumber, positions }) => ({
           vehicleNumber,
+          // Again, only one sequence per vehicle for the reference journey pattern
           sequences: [positions.map(({ time, distanceFromStart, status, prognosed }) => ({
             time,
             distance: distanceFromStart,
@@ -535,14 +569,15 @@ export default class MareyDiagram {
         firstAndLastTimes,
       }));
 
-    // Then, for the "other" journey patterns which match in at least one link with
-    // the refrence journey pattern.
+    // Then compute the trip drawing information for the other journey patterns that share
+    // at least one link with the reference JP
     for (const otherJP of this.journeyPatternMix.otherJPs) {
+      // Iterate over the trips of the journey pattern
       for (const vehicleJourney of otherJP.journeyPattern.vehicleJourneys) {
         const staticSequences = [];
 
         // For each trip of the "other" journey patterns, iterate over the sequences
-        // shared with the reference journey pattern and add the corresponding "timinglinks".
+        // shared with the reference journey pattern and add the corresponding "timinglinks"
         const { referenceSequences, otherSequences } = otherJP.sharedSequences;
         for (let i = 0; i < referenceSequences.length; i += 1) {
           const refSequence = referenceSequences[i];
@@ -555,32 +590,48 @@ export default class MareyDiagram {
         }
 
         const realtimeSequences = [];
+        // Iterate over each of the real time vehicles
         for (const { vehicleNumber, positions } of vehicleJourney.realTimeData) {
           const vehicleSequences = [];
 
+          // Iterate over the shared sequence
           for (let i = 0; i < referenceSequences.length; i += 1) {
+            // Filter out last stop of the sequence because it is not valid as "last stop"
             const refSequence = referenceSequences[i].slice(0, -1);
             const otherSequence = otherSequences[i].slice(0, -1);
 
+            // For each shared sequence, add the positions data of the current trip by mapping
+            // the distance relative to the last stop of the trip to the absolute distance
+            // in the reference journey pattern
             const vehicleSequence = positions
               .filter(({ lastStopIndex }) => otherSequence.includes(lastStopIndex))
               .map(({ time, distanceSinceLastStop, lastStopIndex, status, prognosed }) => {
+                // Find the index of the last stop before the current position
+                // in the reference journey pattern
                 const lastStopRefIndex = refSequence[otherSequence.indexOf(lastStopIndex)];
+                // Get distance of last stop in the reference journey pattern
                 const lastStopRefDistance = this.journeyPatternMix
                   .referenceJP
                   .distances[lastStopRefIndex];
 
                 return {
                   time,
-                  distance: distanceSinceLastStop + lastStopRefDistance,
                   status,
                   prognosed,
+                  // Map the distance by adding the distance of the last stop in the reference
+                  // journey pattern to the distance since the last stop
+                  distance: distanceSinceLastStop + lastStopRefDistance,
                 };
               });
 
+            // Filter out sequences with zero length (can happen that a vehicle belonging to a
+            // journey pattern that shares >1 link(s) with the reference one does not have any
+            // positions to be drawn because the positions are not part of the shared links)
             if (vehicleSequence.length) vehicleSequences.push(vehicleSequence);
           }
 
+          // Filter out vehicles without any position information (can happen that a vehicle
+          // does not have any realtime position data)
           if (vehicleSequences.length) {
             realtimeSequences.push({
               vehicleNumber,
@@ -605,6 +656,14 @@ export default class MareyDiagram {
    * Draw the trips on the diagram
    */
   drawTrips() {
+    // TODO: move these constants in a separate config file
+    const selectedTripStaticStopRadius = 3;
+    const selectedTripRTposRadius = 3;
+    const selectedTripRadius = 6;
+    const deSelectedTripStaticStopRadius = 2;
+    const deSelectedTripRTposRadius = 2;
+    const deSelectedTripRadius = 3;
+
     // Determines if a trip is in the currently selected domain
     const tripInSelectedDomain = (trip) => {
       const [minShownTime, maxShownTime] = this.yScale.domain();
@@ -644,9 +703,10 @@ export default class MareyDiagram {
         .text(({ code }) => code);
       // Add 'selected' class to the trip SVG group
       tripSel.classed('selected', true);
-      tripSel.selectAll('circle.scheduledStop').attr('r', 3);
+      tripSel.selectAll('circle.static-stop').attr('r', selectedTripStaticStopRadius);
+      tripSel.selectAll('circle.rt-position').attr('r', selectedTripRTposRadius);
       // In the map, highlight the vehicle
-      d3.select(`#map g.trip[data-code='${trip.code}'] circle`).attr('r', 6);
+      d3.select(`#map g.trip[data-code='${trip.code}'] circle`).attr('r', selectedTripRadius);
     }
 
     // Handle mouse out of trip event
@@ -655,98 +715,112 @@ export default class MareyDiagram {
       const tripSel = d3.select(this);
       tripSel.select('text.tripLabel').remove();
       tripSel.classed('selected', false);
-      tripSel.selectAll('circle.scheduledStop').attr('r', 2);
-      d3.select(`#map g.trip[data-code='${trip.code}'] circle`).attr('r', 3);
+
+      tripSel.selectAll('circle.static-stop').attr('r', deSelectedTripStaticStopRadius);
+      tripSel.selectAll('circle.rt-position').attr('r', deSelectedTripRTposRadius);
+      d3.select(`#map g.trip[data-code='${trip.code}'] circle`).attr('r', deSelectedTripRadius);
     }
 
     // Trip enter
-    const tripsEnterSel = tripsSel.enter().append('g')
+    const tripsEnterUpdateSel = tripsSel.enter().append('g')
       .attr('class', 'trip')
       .attr('data-trip-code', ({ code }) => code)
       .on('mouseover', tripMouseOver)
-      .on('mouseout', tripMouseOut);
+      .on('mouseout', tripMouseOut)
+      // Trip enter + update
+      .merge(tripsSel);
 
-    // Trip enter + update > static schedule staticSequences selection
-    const staticSequencesSel = tripsEnterSel.merge(tripsSel)
+    // Trip enter + update > static sequences selection
+    const staticSequencesSel = tripsEnterUpdateSel
       .selectAll('path.static-sequence')
       .data(({ staticSequences }) => staticSequences);
 
-    // Trip enter + update > static schedule staticSequences exit
+    // Trip enter + update > static sequences exit
     staticSequencesSel.exit().remove();
 
-    const sequenceGenerator = d3.line()
-      .x(({ distance }) => this.xScale(distance))
-      .y(({ time }) => this.yScale(time));
-
-    // Trip enter + update > static schedule staticSequences enter
+    // Trip enter + update > static sequences enter
     staticSequencesSel.enter()
       .append('path')
       .attr('class', 'static-sequence')
-      // Trip enter + update > static schedule staticSequences enter + update
+      // Trip enter + update > static sequences enter + update
       .merge(staticSequencesSel)
-      .attr('d', schedule => sequenceGenerator(schedule));
+      .attr('d', schedule => this.tripLineGenerator(schedule));
 
-    // Trip enter + update > circle stops selection
-    const staticStopsSel = tripsEnterSel.merge(tripsSel)
+    // Trip enter + update > static stops selection
+    const staticStopsSel = tripsEnterUpdateSel
       .selectAll('circle.static-stop')
       .data(({ staticSequences }) => flatten(staticSequences));
 
-    // Trip enter + update > circle stops exit
+    // Trip enter + update > static stops exit
     staticStopsSel.exit().remove();
 
-    // Trip enter + update > circle stops enter
+    // Trip enter + update > static stops enter
     staticStopsSel.enter()
       .append('circle')
       .attr('class', 'static-stop')
-      .attr('r', 1.5)
+      .attr('r', deSelectedTripStaticStopRadius)
       .attr('cx', ({ distance }) => this.xScale(distance))
       .merge(staticStopsSel)
       .attr('cy', ({ time }) => this.yScale(time));
 
-    const realtimeVehiclesSel = tripsEnterSel.merge(tripsSel)
+    // Trip enter + update > realtime vehicle sequences selection
+    const realtimeVehiclesSel = tripsEnterUpdateSel
       .selectAll('g.vehicle')
       .data(({ realtimeSequences }) => realtimeSequences);
 
+    // Trip enter + update > realtime vehicle sequences exit
     realtimeVehiclesSel.exit().remove();
 
+    // Trip enter + update > realtime vehicle sequences enter
     const realtimeVehiclesEnterUpdateSel = realtimeVehiclesSel.enter()
       .append('g')
       .attr('class', 'vehicle')
       .attr('data-vehicle-number', ({ vehicleNumber }) => vehicleNumber)
+      // Trip enter + update > realtime vehicle sequences enter + update
       .merge(realtimeVehiclesSel);
 
+    // Trip enter + update > realtime vehicle sequences > realtime link selection
     const realtimeVehiclesLinksSel = realtimeVehiclesEnterUpdateSel
-      .selectAll('line.pos-link')
-      .data(({ sequences }) => flatten(sequences.map(sequence => this.getPositionLinks(sequence))));
+      .selectAll('line.rt-link')
+      // Compute the realtime links for each sequence and make a single array out of it
+      .data(
+        ({ sequences }) => flatten(sequences.map(sequence => this.getRealtimeLinks(sequence))),
+        ({ vehicleNumber }) => vehicleNumber,
+      );
 
+    // Trip enter + update > realtime vehicle sequences > realtime link exit
     realtimeVehiclesLinksSel.exit().remove();
 
+    // Trip enter + update > realtime vehicle sequences > realtime link enter
     realtimeVehiclesLinksSel.enter()
       .append('line')
-      // Trip > vehicle > line enter + update
+      // Trip enter + update > realtime vehicle sequences > realtime link enter + update
       .merge(realtimeVehiclesLinksSel)
-      .attr('class', ({ status, prognosed }) =>
-        `pos-link ${status} ${prognosed ? 'prognosed' : ''}`)
+      .attr('class', ({ status }) => `rt-link ${status}`)
+      .classed('prognosed', ({ prognosed }) => prognosed)
       .attr('x1', ({ distanceA }) => this.xScale(distanceA))
       .attr('x2', ({ distanceB }) => this.xScale(distanceB))
       .attr('y1', ({ timeA }) => this.yScale(timeA))
       .attr('y2', ({ timeB }) => this.yScale(timeB));
 
-    const realtimeVehiclesCirclesSel = realtimeVehiclesEnterUpdateSel
-      .selectAll('circle.position')
-      // Draw the dots representing the positions only at the maximum zoom level
+    // Trip enter + update > realtime vehicle sequences > realtime position selection
+    const realtimeVehiclesPositionsSel = realtimeVehiclesEnterUpdateSel
+      .selectAll('circle.rt-position')
+      // Draw the circles representing the positions only at the maximum zoom level
       .data(({ sequences }) => (this.currentApproximation.showPosDots ? flatten(sequences) : []));
 
-    realtimeVehiclesCirclesSel.exit().remove();
+    // Trip enter + update > realtime vehicle sequences > realtime position exit
+    realtimeVehiclesPositionsSel.exit().remove();
 
-    realtimeVehiclesCirclesSel.enter()
+    // Trip enter + update > realtime vehicle sequences > realtime position enter
+    realtimeVehiclesPositionsSel.enter()
       .append('circle')
-      .attr('class', ({ status, prognosed }) =>
-        `position ${status} ${prognosed ? 'prognosed' : ''}`)
-      .attr('r', '1.5')
+      .attr('class', ({ status }) => `rt-position ${status}`)
+      .classed('prognosed', ({ prognosed }) => prognosed)
+      .attr('r', deSelectedTripRTposRadius)
       .attr('cx', ({ distance }) => this.xScale(distance))
-      // Trip > vehicle > circle enter + update
-      .merge(realtimeVehiclesCirclesSel)
+      // Trip enter + update > realtime vehicle sequences > realtime position enter
+      .merge(realtimeVehiclesPositionsSel)
       .attr('cy', ({ time }) => this.yScale(time));
   }
 }

--- a/src/js/viz_components/mareydiagram.js
+++ b/src/js/viz_components/mareydiagram.js
@@ -510,8 +510,14 @@ export default class MareyDiagram {
     return posLinks;
   }
 
+  /**
+   *  Compute information needed to draw the trips on the Marey diagram
+   * @return {Object} - Trip drawing information
+   */
   computeTrips() {
     const trips = [];
+    // We need to chop the trip into all the stopA-stopB segments
+    // First, we do it for the trips of the reference journey pattern.
     for (const vehicleJourney of this.journeyPatternMix.referenceJP.vehicleJourneys) {
       const links = [];
       const { staticSchedule } = vehicleJourney;
@@ -528,18 +534,27 @@ export default class MareyDiagram {
         };
         links.push(link);
       }
+      // We store the code of the trip, the links that make it and the first and last times.
       trips.push({
         code: vehicleJourney.code,
         links,
         firstAndLastTimes: vehicleJourney.firstAndLastTimes,
       });
     }
+    // Then, for the "other" journey patterns which match in at least one link with
+    // the refrence journey pattern.e
     for (const otherJP of this.journeyPatternMix.otherJPs) {
       for (const vehicleJourney of otherJP.journeyPattern.vehicleJourneys) {
         const links = [];
+        // For each trip of the "other" journey patterns, iterate over the segments shared with the
+        // reference journey pattern and add the corresponding "timinglink".
         for (const { withinItself, withinOther } of otherJP.sharedLinks) {
           const link = {
             start: {
+              // The *2 factor is because the times array is twice as long as the distances one,
+              // since it includes arrival and departure times at each stop. For now,
+              // we don't use this information.
+              // TODO: use arrival and departure times for more accurate representation
               time: vehicleJourney.times[withinOther[0] * 2],
               distance: this.journeyPatternMix.referenceJP.distances[withinItself[0]],
             },
@@ -662,7 +677,7 @@ export default class MareyDiagram {
     staticStopsSel.enter()
       .append('circle')
       .attr('class', 'static-stop')
-      .attr('r', '2')
+      .attr('r', 1.5)
       .attr('cx', ({ distance }) => this.xScale(distance))
       .merge(staticStopsSel)
       .attr('cy', ({ time }) => this.yScale(time));

--- a/src/js/viz_components/mareydiagram.js
+++ b/src/js/viz_components/mareydiagram.js
@@ -118,9 +118,13 @@ export default class MareyDiagram {
       // Same as above
       .on('brush end', () => { this.brushed(); });
 
+    // Select the first two hours in the domain in the beginning
+    const initialEndTime = this.yScrollScale.domain()[0];
+    initialEndTime.setHours(initialEndTime.getHours() + 2);
+
     this.scrollGroup
       .call(this.brushBehaviour)
-      .call(this.brushBehaviour.move, [0, this.yScrollScale.range()[1] / 4]);
+      .call(this.brushBehaviour.move, [0, this.yScrollScale(initialEndTime)]);
   }
 
   /**

--- a/src/js/viz_components/mareydiagram.js
+++ b/src/js/viz_components/mareydiagram.js
@@ -6,6 +6,7 @@ import { select, mouse, event as d3event } from 'd3-selection';
 import { line } from 'd3-shape';
 import { zoom, zoomIdentity } from 'd3-zoom';
 import { brushY } from 'd3-brush';
+import { flatten } from 'lodash';
 
 const d3 = Object.assign({}, {
   timeParse,
@@ -640,30 +641,21 @@ export default class MareyDiagram {
       .attr('d', schedule => sequenceGenerator(schedule));
 
     // Trip enter + update > circle stops selection
-    // const staticStopsSel = tripsEnterSel.merge(tripsSel)
-    //   .selectAll('circle.static-stop')
-    //   .data(({ links }) => {
-    //     // Get all the stops that the trip has made, by considering all the vertexes
-    //     // of the static schedule links and deduplicating them using an object
-    //     const stops = {};
-    //     for (const link of links) {
-    //       stops[link.start.distance] = link.start.time;
-    //       stops[link.end.distance] = link.end.time;
-    //     }
-    //     return Array.from(Object.entries(stops).map(([distance, time]) => ({ distance, time })));
-    //   });
+    const staticStopsSel = tripsEnterSel.merge(tripsSel)
+      .selectAll('circle.static-stop')
+      .data(({ sequences }) => flatten(sequences));
 
-    // // Trip enter + update > circle stops exit
-    // staticStopsSel.exit().remove();
+    // Trip enter + update > circle stops exit
+    staticStopsSel.exit().remove();
 
-    // // Trip enter + update > circle stops enter
-    // staticStopsSel.enter()
-    //   .append('circle')
-    //   .attr('class', 'static-stop')
-    //   .attr('r', 1.5)
-    //   .attr('cx', ({ distance }) => this.xScale(distance))
-    //   .merge(staticStopsSel)
-    //   .attr('cy', ({ time }) => this.yScale(time));
+    // Trip enter + update > circle stops enter
+    staticStopsSel.enter()
+      .append('circle')
+      .attr('class', 'static-stop')
+      .attr('r', 1.5)
+      .attr('cx', ({ distance }) => this.xScale(distance))
+      .merge(staticStopsSel)
+      .attr('cy', ({ time }) => this.yScale(time));
 
     // const vehiclesPosLinksSel = vehiclesEnterUpdateSel.selectAll('line.pos-link')
     //   .data(({ positions }) => this.getPositionLinks(positions));

--- a/src/js/viz_components/mareydiagram.js
+++ b/src/js/viz_components/mareydiagram.js
@@ -525,12 +525,12 @@ export default class MareyDiagram {
         ],
         realtimeSequences: realTimeData.map(({ vehicleNumber, positions }) => ({
           vehicleNumber,
-          sequences: positions.map(({ time, distanceFromStart, status, prognosed }) => ({
+          sequences: [positions.map(({ time, distanceFromStart, status, prognosed }) => ({
             time,
             distance: distanceFromStart,
             status,
             prognosed,
-          })),
+          }))],
         })),
         firstAndLastTimes,
       }));
@@ -562,7 +562,7 @@ export default class MareyDiagram {
             const refSequence = referenceSequences[i].slice(0, -1);
             const otherSequence = otherSequences[i].slice(0, -1);
 
-            vehicleSequences.push(positions
+            const vehicleSequence = positions
               .filter(({ lastStopIndex }) => otherSequence.includes(lastStopIndex))
               .map(({ time, distanceSinceLastStop, lastStopIndex, status, prognosed }) => {
                 const lastStopRefIndex = refSequence[otherSequence.indexOf(lastStopIndex)];
@@ -576,13 +576,17 @@ export default class MareyDiagram {
                   status,
                   prognosed,
                 };
-              }));
+              });
+
+            if (vehicleSequence.length) vehicleSequences.push(vehicleSequence);
           }
 
-          realtimeSequences.push({
-            vehicleNumber,
-            sequences: vehicleSequences,
-          });
+          if (vehicleSequences.length) {
+            realtimeSequences.push({
+              vehicleNumber,
+              sequences: vehicleSequences,
+            });
+          }
         }
 
         trips.push({

--- a/src/js/viz_components/mareydiagram.js
+++ b/src/js/viz_components/mareydiagram.js
@@ -707,23 +707,24 @@ export default class MareyDiagram {
 
     realtimeVehiclesSel.exit().remove();
 
-    const realtimeVehiclesEnterSel = realtimeVehiclesSel.enter()
+    const realtimeVehiclesEnterUpdateSel = realtimeVehiclesSel.enter()
       .append('g')
       .attr('class', 'vehicle')
-      .attr('data-vehicle-number', ({ vehicleNumber }) => vehicleNumber);
+      .attr('data-vehicle-number', ({ vehicleNumber }) => vehicleNumber)
+      .merge(realtimeVehiclesSel);
 
-    const realtimeVehiclesSequencesSel = realtimeVehiclesEnterSel.merge(realtimeVehiclesSel)
+    const realtimeVehiclesSequencesSel = realtimeVehiclesEnterUpdateSel
       .selectAll('g.sequence')
       .data(({ sequences }) => sequences);
 
     realtimeVehiclesSequencesSel.exit().remove();
 
-    const realtimeVehiclesSequencesEnterSel = realtimeVehiclesSequencesSel.enter()
+    const realtimeVehiclesSequencesEnterUpdateSel = realtimeVehiclesSequencesSel.enter()
       .append('g')
-      .attr('class', 'sequence');
+      .attr('class', 'sequence')
+      .merge(realtimeVehiclesSequencesSel);
 
-    const realtimeVehiclesSequencesLinksSel = realtimeVehiclesSequencesEnterSel
-      .merge(realtimeVehiclesSequencesSel)
+    const realtimeVehiclesSequencesLinksSel = realtimeVehiclesSequencesEnterUpdateSel
       .selectAll('line.pos-link')
       .data(sequence => this.getPositionLinks(sequence));
 
@@ -740,95 +741,21 @@ export default class MareyDiagram {
       .attr('y1', ({ timeA }) => this.yScale(timeA))
       .attr('y2', ({ timeB }) => this.yScale(timeB));
 
-    // const vehiclesPosLinksSel = vehiclesEnterUpdateSel.selectAll('line.pos-link')
-    //   .data(({ positions }) => this.getPositionLinks(positions));
+    const realtimeVehiclesSequencesCirclesSel = realtimeVehiclesSequencesEnterUpdateSel
+      .selectAll('circle.position')
+      // Draw the dots representing the positions only at the maximum zoom level
+      .data(sequence => (this.currentApproximation.showPosDots ? sequence : []));
 
-    // vehiclesPosLinksSel.exit().remove();
+    realtimeVehiclesSequencesCirclesSel.exit().remove();
 
-    // // Trip > vehicle > line enter
-    // vehiclesPosLinksSel.enter()
-    //   .append('line')
-    //   // Trip > vehicle > line enter + update
-    //   .merge(vehiclesPosLinksSel)
-    //   .attr('class', ({ status, prognosed }) =>
-    //      `pos-link ${status} ${prognosed ? 'prognosed' : ''}`)
-    //   .attr('x1', ({ distanceA }) => this.xScale(distanceA))
-    //   .attr('x2', ({ distanceB }) => this.xScale(distanceB))
-    //   .attr('y1', ({ timeA }) => this.yScale(timeA))
-    //   .attr('y2', ({ timeB }) => this.yScale(timeB));
-
-    // Trip enter > path
-    // tripsEnterSel
-    //   .append('path')
-    //   .merge(tripsSel.select('path'))
-    //   .attr('d', ({ staticSchedule }) => this.tripLineGenerator(staticSchedule));
-
-    // TODO:
-    // instead of using <path> elements, use separate <line>s like for the realtime data
-
-    // Trip enter > circle selection
-    // const tripsScheduledStopsSel = tripsEnterSel.merge(tripsSel)
-    //   .selectAll('circle.scheduledStop')
-    //   .data(({ staticSchedule }) => staticSchedule);
-
-    // // Trip enter > circle
-    // tripsScheduledStopsSel.enter()
-    //   .append('circle')
-    //   .attr('class', 'scheduledStop')
-    //   .attr('r', '2')
-    //   .attr('cx', ({ distance }) => this.xScale(distance))
-    //   .merge(tripsScheduledStopsSel)
-    //   .attr('cy', ({ time }) => this.yScale(time));
-
-    // // Trip enter > vehicle selection
-    // const vehiclesSel = tripsSel.selectAll('g.vehicle')
-    //   .data(({ vehicles }) => vehicles, ({ vehicleNumber }) => vehicleNumber);
-
-    // // Trip > vehicle exit
-    // vehiclesSel.exit().remove();
-
-    // // Trip > vehicle enter,
-    // const vehiclesEnterSel = vehiclesSel.enter().append('g')
-    //   .attr('class', 'vehicle')
-    //   .attr('data-vehicle-n', ({ vehicleNumber }) => vehicleNumber);
-
-    // // Trip > vehicle enter + update
-    // const vehiclesEnterUpdateSel = vehiclesSel.merge(vehiclesEnterSel);
-
-    // // Trip > vehicle enter + update > circle
-    // const vehiclesPosSel = vehiclesEnterUpdateSel
-    //   .selectAll('circle.position')
-    //   // Draw the dots representing the positions only at the maximum zoom level
-    //   .data(({ positions }) => (this.currentApproximation.showPosDots ? positions : []));
-
-    // vehiclesPosSel.exit().remove();
-
-    // vehiclesPosSel.enter()
-    //   .append('circle')
-    //   .attr('class', ({ status, prognosed }) =>
-    //     `position ${status} ${prognosed ? 'prognosed' : ''}`)
-    //   .attr('r', '1.5')
-    //   .attr('cx', ({ distance }) => this.xScale(distance))
-    //   // Trip > vehicle > circle enter + update
-    //   .merge(vehiclesPosSel)
-    //   .attr('cy', ({ time }) => this.yScale(time));
-
-    // // Trip > vehicle > line
-    // const vehiclesPosLinksSel = vehiclesEnterUpdateSel.selectAll('line.pos-link')
-    //   .data(({ positions }) => this.getPositionLinks(positions));
-
-    // vehiclesPosLinksSel.exit().remove();
-
-    // // Trip > vehicle > line enter
-    // vehiclesPosLinksSel.enter()
-    //   .append('line')
-    //   // Trip > vehicle > line enter + update
-    //   .merge(vehiclesPosLinksSel)
-    //   .attr('class', ({ status, prognosed }) =>
-    //      `pos-link ${status} ${prognosed ? 'prognosed' : ''}`)
-    //   .attr('x1', ({ distanceA }) => this.xScale(distanceA))
-    //   .attr('x2', ({ distanceB }) => this.xScale(distanceB))
-    //   .attr('y1', ({ timeA }) => this.yScale(timeA))
-    //   .attr('y2', ({ timeB }) => this.yScale(timeB));
+    realtimeVehiclesSequencesCirclesSel.enter()
+      .append('circle')
+      .attr('class', ({ status, prognosed }) =>
+        `position ${status} ${prognosed ? 'prognosed' : ''}`)
+      .attr('r', '1.5')
+      .attr('cx', ({ distance }) => this.xScale(distance))
+      // Trip > vehicle > circle enter + update
+      .merge(realtimeVehiclesSequencesCirclesSel)
+      .attr('cy', ({ time }) => this.yScale(time));
   }
 }

--- a/src/js/viz_components/mareydiagram.js
+++ b/src/js/viz_components/mareydiagram.js
@@ -594,8 +594,6 @@ export default class MareyDiagram {
       }
     }
 
-    console.log(trips);
-
     return trips;
   }
 

--- a/src/js/viz_components/mareydiagram.js
+++ b/src/js/viz_components/mareydiagram.js
@@ -594,6 +594,8 @@ export default class MareyDiagram {
       }
     }
 
+    console.log(trips);
+
     return trips;
   }
 
@@ -698,6 +700,45 @@ export default class MareyDiagram {
       .attr('cx', ({ distance }) => this.xScale(distance))
       .merge(staticStopsSel)
       .attr('cy', ({ time }) => this.yScale(time));
+
+    const realtimeVehiclesSel = tripsEnterSel.merge(tripsSel)
+      .selectAll('g.vehicle')
+      .data(({ realtimeSequences }) => realtimeSequences);
+
+    realtimeVehiclesSel.exit().remove();
+
+    const realtimeVehiclesEnterSel = realtimeVehiclesSel.enter()
+      .append('g')
+      .attr('class', 'vehicle')
+      .attr('data-vehicle-number', ({ vehicleNumber }) => vehicleNumber);
+
+    const realtimeVehiclesSequencesSel = realtimeVehiclesEnterSel.merge(realtimeVehiclesSel)
+      .selectAll('g.sequence')
+      .data(({ sequences }) => sequences);
+
+    realtimeVehiclesSequencesSel.exit().remove();
+
+    const realtimeVehiclesSequencesEnterSel = realtimeVehiclesSequencesSel.enter()
+      .append('g')
+      .attr('class', 'sequence');
+
+    const realtimeVehiclesSequencesLinksSel = realtimeVehiclesSequencesEnterSel
+      .merge(realtimeVehiclesSequencesSel)
+      .selectAll('line.pos-link')
+      .data(sequence => this.getPositionLinks(sequence));
+
+    realtimeVehiclesSequencesLinksSel.exit().remove();
+
+    realtimeVehiclesSequencesLinksSel.enter()
+      .append('line')
+      // Trip > vehicle > line enter + update
+      .merge(realtimeVehiclesSequencesLinksSel)
+      .attr('class', ({ status, prognosed }) =>
+        `pos-link ${status} ${prognosed ? 'prognosed' : ''}`)
+      .attr('x1', ({ distanceA }) => this.xScale(distanceA))
+      .attr('x2', ({ distanceB }) => this.xScale(distanceB))
+      .attr('y1', ({ timeA }) => this.yScale(timeA))
+      .attr('y2', ({ timeB }) => this.yScale(timeB));
 
     // const vehiclesPosLinksSel = vehiclesEnterUpdateSel.selectAll('line.pos-link')
     //   .data(({ positions }) => this.getPositionLinks(positions));

--- a/src/js/viz_components/mareydiagram.js
+++ b/src/js/viz_components/mareydiagram.js
@@ -132,8 +132,11 @@ export default class MareyDiagram {
    * Set up the zoom and brush behaviours
    */
   zoomAndBrushSetup() {
+    // Since we haven't selected a range yet, this will get the domain of the entire day
+    const minutesInDomain = Math.floor(this.secondsInDomain / 60);
     this.zoomBehaviour = d3.zoom()
-      .scaleExtent([1, 2000])
+      // Base maximum zoom on the number of minutes in the domain for the current day
+      .scaleExtent([1, minutesInDomain * 1.6667])
       .extent([[0, 0], [this.dims.marey.innerWidth, this.dims.marey.innerHeight]])
       .translateExtent([[0, 0], [this.dims.marey.innerWidth, this.dims.marey.innerHeight]])
       // We encapsulate this.zoomed in a closure so that we don't lose the "this" context

--- a/src/js/viz_components/mareydiagram.js
+++ b/src/js/viz_components/mareydiagram.js
@@ -150,8 +150,12 @@ export default class MareyDiagram {
       .on('brush end', () => { this.brushed(); });
 
     // Select the first two hours in the domain in the beginning
-    const initialEndTime = this.yScrollScale.domain()[0];
+    let [initialEndTime] = this.yScrollScale.domain();
     initialEndTime.setHours(initialEndTime.getHours() + 2);
+    // If the total domain is less than two hours, select the entire domain
+    if (initialEndTime > this.yScrollScale.domain()[1]) {
+      [, initialEndTime] = this.yScrollScale.domain();
+    }
 
     this.scrollGroup
       .call(this.brushBehaviour)

--- a/src/js/viz_components/mareydiagram.js
+++ b/src/js/viz_components/mareydiagram.js
@@ -715,27 +715,16 @@ export default class MareyDiagram {
       .attr('data-vehicle-number', ({ vehicleNumber }) => vehicleNumber)
       .merge(realtimeVehiclesSel);
 
-    const realtimeVehiclesSequencesSel = realtimeVehiclesEnterUpdateSel
-      .selectAll('g.sequence')
-      .data(({ sequences }) => sequences);
-
-    realtimeVehiclesSequencesSel.exit().remove();
-
-    const realtimeVehiclesSequencesEnterUpdateSel = realtimeVehiclesSequencesSel.enter()
-      .append('g')
-      .attr('class', 'sequence')
-      .merge(realtimeVehiclesSequencesSel);
-
-    const realtimeVehiclesSequencesLinksSel = realtimeVehiclesSequencesEnterUpdateSel
+    const realtimeVehiclesLinksSel = realtimeVehiclesEnterUpdateSel
       .selectAll('line.pos-link')
-      .data(sequence => this.getPositionLinks(sequence));
+      .data(({ sequences }) => flatten(sequences.map(sequence => this.getPositionLinks(sequence))));
 
-    realtimeVehiclesSequencesLinksSel.exit().remove();
+    realtimeVehiclesLinksSel.exit().remove();
 
-    realtimeVehiclesSequencesLinksSel.enter()
+    realtimeVehiclesLinksSel.enter()
       .append('line')
       // Trip > vehicle > line enter + update
-      .merge(realtimeVehiclesSequencesLinksSel)
+      .merge(realtimeVehiclesLinksSel)
       .attr('class', ({ status, prognosed }) =>
         `pos-link ${status} ${prognosed ? 'prognosed' : ''}`)
       .attr('x1', ({ distanceA }) => this.xScale(distanceA))
@@ -743,21 +732,21 @@ export default class MareyDiagram {
       .attr('y1', ({ timeA }) => this.yScale(timeA))
       .attr('y2', ({ timeB }) => this.yScale(timeB));
 
-    const realtimeVehiclesSequencesCirclesSel = realtimeVehiclesSequencesEnterUpdateSel
+    const realtimeVehiclesCirclesSel = realtimeVehiclesEnterUpdateSel
       .selectAll('circle.position')
       // Draw the dots representing the positions only at the maximum zoom level
-      .data(sequence => (this.currentApproximation.showPosDots ? sequence : []));
+      .data(({ sequences }) => (this.currentApproximation.showPosDots ? flatten(sequences) : []));
 
-    realtimeVehiclesSequencesCirclesSel.exit().remove();
+    realtimeVehiclesCirclesSel.exit().remove();
 
-    realtimeVehiclesSequencesCirclesSel.enter()
+    realtimeVehiclesCirclesSel.enter()
       .append('circle')
       .attr('class', ({ status, prognosed }) =>
         `position ${status} ${prognosed ? 'prognosed' : ''}`)
       .attr('r', '1.5')
       .attr('cx', ({ distance }) => this.xScale(distance))
       // Trip > vehicle > circle enter + update
-      .merge(realtimeVehiclesSequencesCirclesSel)
+      .merge(realtimeVehiclesCirclesSel)
       .attr('cy', ({ time }) => this.yScale(time));
   }
 }

--- a/src/scss/main.scss
+++ b/src/scss/main.scss
@@ -91,8 +91,9 @@ svg {
     }
   }
 
-  g.trip line.static-link {
+  path.static-sequence {
     stroke: dimgray;
+    fill: none;
   }
 
   g.vehicle circle.position {

--- a/src/scss/main.scss
+++ b/src/scss/main.scss
@@ -96,7 +96,7 @@ svg {
     fill: none;
   }
 
-  g.vehicle circle.position {
+  g.vehicle circle.rt-position {
     &.early {
       fill: $vehicle-early-color;
     }
@@ -110,7 +110,7 @@ svg {
     }
   }
 
-  g.vehicle line.pos-link {
+  g.vehicle line.rt-link {
     &.early {
       stroke: $vehicle-early-color;
     }

--- a/src/scss/main.scss
+++ b/src/scss/main.scss
@@ -91,8 +91,8 @@ svg {
     }
   }
 
-  .trip path {
-    fill: none;
+  g.trip line.static-link {
+    stroke: dimgray;
   }
 
   g.vehicle circle.position {


### PR DESCRIPTION
As agreed, the first step to the support of multiple journey patterns is the selection of a certain line and direction.
The journey pattern with the selected line-direction combination that has the longest list of stops is taken as a reference, and drawn as before in the Marey.
On top of this, all the other journey patterns that share the same line and direction are drawn on top of the reference journey pattern.
For now, only the reference JP is drawn.

[new PR because something went wrong with the last one]