### PR TITLE
Optimize realtime path drawing in Marey grouping similar lines

### DIFF
--- a/src/scss/main.scss
+++ b/src/scss/main.scss
@@ -38,6 +38,7 @@ svg {
   line, path {
     stroke: black;
     stroke-width: 1;
+    fill: none;
   }
 }
 
@@ -93,7 +94,6 @@ svg {
 
   path.static-sequence {
     stroke: dimgray;
-    fill: none;
   }
 
   g.vehicle circle.rt-position {
@@ -110,7 +110,7 @@ svg {
     }
   }
 
-  g.vehicle line.rt-link {
+  g.vehicle path.rt-sequence {
     &.early {
       stroke: $vehicle-early-color;
     }


### PR DESCRIPTION
Instead of using a <line> element for each realtime position, now all the <line>s with the same status and prognosis are grouped into a single <path> to reduce the number of nodes and improve the rendering performance.
The approximation of the realtime trajectory basing on the zoom is disabled, the zoom only changes the visibility of the realtime position dots.